### PR TITLE
Capture console logs from devtools in main console

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -110,6 +110,28 @@ function createWindow(hash = '') {
     }
   })
 
+  // Capture all console messages from the renderer process
+  win.webContents.on('console-message', (event, level, message, line, sourceId) => {
+    const levels = ['log', 'warn', 'error', 'info', 'debug']
+    const prefix = sourceId ? `[${sourceId.split('/').pop()}:${line}]` : '[Renderer]'
+    switch (levels[level] || 'log') {
+      case 'warn':
+        console.warn(prefix, message)
+        break
+      case 'error':
+        console.error(prefix, message)
+        break
+      case 'info':
+        console.info(prefix, message)
+        break
+      case 'debug':
+        console.debug(prefix, message)
+        break
+      default:
+        console.log(prefix, message)
+    }
+  })
+
   // Set 2:1 aspect ratio immediately after creation
   win.setAspectRatio(2)
 


### PR DESCRIPTION
With this PR we don't have to constantly have devtools window open but we can just see the logs inside the main console.

## Before

<img width="568" alt="Screenshot 2025-03-02 at 12 40 21" src="https://github.com/user-attachments/assets/42a19c77-f0b9-456f-ba2b-c8e17a791fbe" />

## After

<img width="418" alt="Screenshot 2025-03-02 at 12 40 48" src="https://github.com/user-attachments/assets/933e3550-0504-4ce1-be4b-056b3c8d32e5" />
